### PR TITLE
👕 Set up `Standard JS` linter

### DIFF
--- a/lib/matchmaker.js
+++ b/lib/matchmaker.js
@@ -1,4 +1,4 @@
-'use babel';
+'use babel'
 
 import _ from 'underscore-plus'
 import pathUtils from 'path'
@@ -18,7 +18,7 @@ export default class Matchmaker {
     return new Matchmaker(path)
   }
 
-  constructor(path) {
+  constructor (path) {
     this.path = path
   }
 
@@ -28,7 +28,7 @@ export default class Matchmaker {
   // Returns a Promise that resolves to:
   // * the {String} representing the absolute path to the complementary file.
   // * `null` if no complementary path is found.
-  complementaryPath() {
+  complementaryPath () {
     return this.findComplementaryPath(atom.project.getPaths(), this.path)
   }
 
@@ -85,7 +85,7 @@ export default class Matchmaker {
   //     directories to drop).
   //
   // Returns a Promise.
-  findComplementaryPath(directoriesToSearch, matcheePath, leadingDirectoriesToExclude = 1) {
+  findComplementaryPath (directoriesToSearch, matcheePath, leadingDirectoriesToExclude = 1) {
     const relativeMatcheePath = atom.project.relativize(matcheePath)
     const partialMatcheePath = this.withoutLeadingDirectory(relativeMatcheePath, leadingDirectoriesToExclude)
     const directoryPattern = this.directoryPattern(partialMatcheePath)
@@ -140,22 +140,22 @@ export default class Matchmaker {
   //   # => false
   //
   // Returns a Boolean.
-  hasDirectory(path) {
-    return pathUtils.dirname(path) != "."
+  hasDirectory (path) {
+    return pathUtils.dirname(path) != '.'
   }
 
   // Internal
-  directoryPattern(path) {
+  directoryPattern (path) {
     if (this.hasDirectory(path)) {
       const directoryPath = pathUtils.dirname(path)
-      return ["**", directoryPath].join(pathUtils.sep)
+      return ['**', directoryPath].join(pathUtils.sep)
     } else {
-      return "**"
+      return '**'
     }
   }
 
   // Internal
-  withoutLeadingDirectory(path, leadingDirectoriesToExclude = 1) {
+  withoutLeadingDirectory (path, leadingDirectoriesToExclude = 1) {
     const directoriesInPath = pathUtils.dirname(path).split(pathUtils.sep)
     const subdirectoriesInPath = _.rest(directoriesInPath, leadingDirectoriesToExclude)
     const basename = pathUtils.basename(path)
@@ -164,7 +164,7 @@ export default class Matchmaker {
   }
 
   // Internal
-  basenamePattern(path) {
+  basenamePattern (path) {
     const basename = pathUtils.basename(path, pathUtils.extname(path))
 
     // TODO Refactor and/or use better names or comments
@@ -173,8 +173,8 @@ export default class Matchmaker {
     // then remove that from the name. If it does NOT end with `_test` or
     // `.test` or `_spec` or `-spec`, then add those items as optional suffixes
     // for the pattern.
-    if (basename.match("(\.test|_test|_spec|-spec)$")) {
-      return basename.replace(new RegExp("(\.test|_test|_spec|-spec)$"), "")
+    if (basename.match('(\.test|_test|_spec|-spec)$')) {
+      return basename.replace(new RegExp('(\.test|_test|_spec|-spec)$'), '')
     } else {
       return `${basename}?(\.test|_test|_spec|-spec)`
     }

--- a/lib/matchmaker.js
+++ b/lib/matchmaker.js
@@ -173,10 +173,10 @@ export default class Matchmaker {
     // then remove that from the name. If it does NOT end with `_test` or
     // `.test` or `_spec` or `-spec`, then add those items as optional suffixes
     // for the pattern.
-    if (basename.match('(\.test|_test|_spec|-spec)$')) {
-      return basename.replace(new RegExp('(\.test|_test|_spec|-spec)$'), '')
+    if (basename.match('(.test|_test|_spec|-spec)$')) {
+      return basename.replace(new RegExp('(.test|_test|_spec|-spec)$'), '')
     } else {
-      return `${basename}?(\.test|_test|_spec|-spec)`
+      return `${basename}?(.test|_test|_spec|-spec)`
     }
   }
 }

--- a/lib/matchmaker.js
+++ b/lib/matchmaker.js
@@ -141,7 +141,7 @@ export default class Matchmaker {
   //
   // Returns a Boolean.
   hasDirectory (path) {
-    return pathUtils.dirname(path) != '.'
+    return pathUtils.dirname(path) !== '.'
   }
 
   // Internal

--- a/lib/matchmaker.js
+++ b/lib/matchmaker.js
@@ -1,12 +1,9 @@
-'use babel'
+const _ = require('underscore-plus')
+const pathUtils = require('path')
+const {PathScanner} = require('scandal')
 
-import _ from 'underscore-plus'
-import pathUtils from 'path'
-import {
-  PathScanner
-} from 'scandal'
-
-export default class Matchmaker {
+module.exports =
+class Matchmaker {
   // Public: Construct a {Matchmaker} for the given path.
   //
   // * `path` A {String} representing the absolute path to the file whose

--- a/lib/significant-other.js
+++ b/lib/significant-other.js
@@ -1,11 +1,7 @@
-'use babel'
+const Matchmaker = require('./matchmaker')
+const {CompositeDisposable} = require('atom')
 
-import Matchmaker from './matchmaker'
-import {
-  CompositeDisposable
-} from 'atom'
-
-export default {
+module.exports = ({
   subscriptions: null,
   cache: {},
   activate (state) {
@@ -62,4 +58,4 @@ export default {
       }
     })
   }
-}
+})

--- a/lib/significant-other.js
+++ b/lib/significant-other.js
@@ -1,4 +1,4 @@
-'use babel';
+'use babel'
 
 import Matchmaker from './matchmaker'
 import {
@@ -8,7 +8,7 @@ import {
 export default {
   subscriptions: null,
   cache: {},
-  activate(state) {
+  activate (state) {
     // Events subscribed to in atom's system can be easily cleaned up with a
     // CompositeDisposable
     this.subscriptions = new CompositeDisposable()
@@ -18,36 +18,36 @@ export default {
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
       'significant-other:toggle': () => this.toggle(),
       'significant-other:clear-cache': () => this.clearCache()
-    }));
+    }))
   },
 
-  deactivate() {
+  deactivate () {
     this.subscriptions.dispose()
     this.cache = {}
   },
 
-  serialize() {
+  serialize () {
     return {
       cache: this.cache
     }
   },
 
-  getFilePath() {
+  getFilePath () {
     return atom.workspace.getActiveTextEditor().getPath()
   },
 
-  clearCache() {
+  clearCache () {
     this.cache = {}
   },
 
-  toggle() {
+  toggle () {
     const filePath = this.getFilePath()
     const matchmaker = Matchmaker.for(filePath)
 
     // use cached path if we can
     if (this.cache[filePath]) {
       atom.workspace.open(this.cache[filePath])
-      return;
+      return
     }
 
     matchmaker.complementaryPath().then((path) => {
@@ -61,5 +61,5 @@ export default {
         atom.notifications.addWarning('No significant other found 😱')
       }
     })
-  },
-};
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,5 +24,13 @@
     "fs-plus": "2.x",
     "scandal": "3.1.x",
     "underscore-plus": "1.x"
+  },
+  "devDependencies": {
+    "standard": "^10.0.3"
+  },
+  "standard": {
+    "globals": [
+      "atom"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     ]
   },
   "scripts": {
-    "lint": "standard --verbose"
+    "lint": "standard --verbose",
+    "test": "npm run lint && apm test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "globals": [
       "atom"
     ]
+  },
+  "scripts": {
+    "lint": "standard --verbose"
   }
 }

--- a/spec/matchmaker-spec.js
+++ b/spec/matchmaker-spec.js
@@ -14,8 +14,6 @@ import os from 'os'
 // Something like:
 //   expect('foo/bar.rb').toHaveComplementaryPath('specs/foo/bar_spec.rb')
 describe('finding the complementary path for a file', () => {
-  let [activationPromise, editor] = []
-
   let projectPath = path.join(os.tmpdir(), 'significant-other-test-fixture')
 
   let setupProject = (rootPath, filePaths) => {
@@ -56,8 +54,7 @@ describe('finding the complementary path for a file', () => {
     waitsForPromise(() => atom.workspace.open())
 
     runs(() => {
-      editor = atom.workspace.getActiveTextEditor()
-      activationPromise = atom.packages.activatePackage('significant-other')
+      atom.packages.activatePackage('significant-other')
     })
   })
 

--- a/spec/matchmaker-spec.js
+++ b/spec/matchmaker-spec.js
@@ -1,11 +1,9 @@
 /* global afterEach, beforeEach, describe, expect, it, runs, waitsFor, waitsForPromise */
 
-'use babel'
-
-import Matchmaker from '../lib/matchmaker'
-import fs from 'fs-plus'
-import path from 'path'
-import os from 'os'
+const Matchmaker = require('../lib/matchmaker')
+const fs = require('fs-plus')
+const path = require('path')
+const os = require('os')
 
 // TODO Consider ditching the test names. Does Jasmine have an equivalent to
 // just `example` in RSpec?

--- a/spec/matchmaker-spec.js
+++ b/spec/matchmaker-spec.js
@@ -1,3 +1,5 @@
+/* global afterEach, beforeEach, describe, expect, it, runs, waitsFor, waitsForPromise */
+
 'use babel'
 
 import Matchmaker from '../lib/matchmaker'

--- a/spec/matchmaker-spec.js
+++ b/spec/matchmaker-spec.js
@@ -1,4 +1,5 @@
-/* global afterEach, beforeEach, describe, expect, it, runs, waitsFor, waitsForPromise */
+/* eslint-env jasmine */
+/* global waitsForPromise */
 
 const Matchmaker = require('../lib/matchmaker')
 const fs = require('fs-plus')

--- a/spec/matchmaker-spec.js
+++ b/spec/matchmaker-spec.js
@@ -13,7 +13,7 @@ import os from 'os'
 // TODO Consider drying up tests: We could define a custom jasmine expectation.
 // Something like:
 //   expect('foo/bar.rb').toHaveComplementaryPath('specs/foo/bar_spec.rb')
-describe("finding the complementary path for a file", () => {
+describe('finding the complementary path for a file', () => {
   let [activationPromise, editor] = []
 
   let projectPath = path.join(os.tmpdir(), 'significant-other-test-fixture')
@@ -63,7 +63,7 @@ describe("finding the complementary path for a file", () => {
 
   afterEach(() => teardownProject(projectPath))
 
-  describe("in a typical Atom package", () => {
+  describe('in a typical Atom package', () => {
     beforeEach(() => {
       // A representative sample of files from the release-notes package
       // (https://github.com/atom/release-notes/tree/v0.51.0)
@@ -78,12 +78,12 @@ describe("finding the complementary path for a file", () => {
         'spec/fixtures/releases-response.json',
         'spec/release-notes-status-bar-spec.coffee',
         'spec/release-notes-view-spec.coffee',
-        'styles/release-notes.less',
+        'styles/release-notes.less'
       ]
       setupProject(projectPath, filePaths)
     })
 
-    it("finds spec for implementation file", () =>
+    it('finds spec for implementation file', () =>
       waitsForPromise(() =>
         Matchmaker.for('lib/release-notes-view.coffee').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -92,7 +92,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds implementation file for spec", () =>
+    it('finds implementation file for spec', () =>
       waitsForPromise(() =>
         Matchmaker.for('spec/release-notes-view-spec.coffee').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -115,12 +115,12 @@ describe("finding the complementary path for a file", () => {
         'package.json',
         'styles/hunk-view.less',
         'test/git-prompt-server.test.js',
-        'test/views/hunk-view.test.js',
+        'test/views/hunk-view.test.js'
       ]
       setupProject(projectPath, filePaths)
     })
 
-    it("finds spec for implementation file", () =>
+    it('finds spec for implementation file', () =>
       waitsForPromise(() =>
         Matchmaker.for('lib/views/hunk-view.js').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -129,7 +129,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds implementation file for spec", () =>
+    it('finds implementation file for spec', () =>
       waitsForPromise(() =>
         Matchmaker.for('test/views/hunk-view.test.js').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -139,7 +139,7 @@ describe("finding the complementary path for a file", () => {
     )
   })
 
-  describe("in a typical Ruby gem", () => {
+  describe('in a typical Ruby gem', () => {
     beforeEach(() => {
       // A representative sample of files from the Octokit gem
       // (https://github.com/octokit/octokit.rb/tree/v3.5.2)
@@ -155,12 +155,12 @@ describe("finding the complementary path for a file", () => {
         'spec/client/authorizations_spec.rb',
         'spec/client/pull_requests_spec.rb',
         'spec/client_spec.rb',
-        'spec/octokit_spec.rb',
+        'spec/octokit_spec.rb'
       ]
       setupProject(projectPath, filePaths)
     })
 
-    it("finds test for implementation file", () =>
+    it('finds test for implementation file', () =>
       waitsForPromise(() =>
         Matchmaker.for('lib/octokit.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -169,7 +169,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds implementation file for test", () =>
+    it('finds implementation file for test', () =>
       waitsForPromise(() =>
         Matchmaker.for('spec/octokit_spec.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -178,7 +178,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds test for nested implementation file", () =>
+    it('finds test for nested implementation file', () =>
       waitsForPromise(() =>
         Matchmaker.for('lib/octokit/client/pull_requests.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -187,7 +187,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds nested implementation file for test", () =>
+    it('finds nested implementation file for test', () =>
       waitsForPromise(() =>
         Matchmaker.for('spec/client/pull_requests_spec.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -197,7 +197,7 @@ describe("finding the complementary path for a file", () => {
     )
   })
 
-  describe("in a typical Rails app", () => {
+  describe('in a typical Rails app', () => {
     beforeEach(() => {
       let filePaths = [
         'README.md',
@@ -214,12 +214,12 @@ describe("finding the complementary path for a file", () => {
         'test/helpers/comments_helper_test.rb',
         'test/helpers/posts_helper_test.rb',
         'test/models/comment_test.rb',
-        'test/models/post_test.rb',
+        'test/models/post_test.rb'
       ]
       setupProject(projectPath, filePaths)
     })
 
-    it("finds controller test for controller implementation", () =>
+    it('finds controller test for controller implementation', () =>
       waitsForPromise(() =>
         Matchmaker.for('app/controllers/posts_controller.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -228,7 +228,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds controller implementation for controller test", () =>
+    it('finds controller implementation for controller test', () =>
       waitsForPromise(() =>
         Matchmaker.for('test/controllers/posts_controller_test.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -237,7 +237,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds model test for model implementation", () =>
+    it('finds model test for model implementation', () =>
       waitsForPromise(() =>
         Matchmaker.for('app/models/post.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -246,7 +246,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds model implementation for model test", () =>
+    it('finds model implementation for model test', () =>
       waitsForPromise(() =>
         Matchmaker.for('test/models/post_test.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -256,19 +256,19 @@ describe("finding the complementary path for a file", () => {
     )
   })
 
-  describe("in the codebase that powers github.com", () => {
+  describe('in the codebase that powers github.com', () => {
     beforeEach(() => {
       let filePaths = [
         'README.md',
         'app/api/gists.rb',
         'app/api/git_commits.rb',
         'test/integration/api/gists_test.rb.rb',
-        'test/integration/api/git_commits_test.rb',
+        'test/integration/api/git_commits_test.rb'
       ]
       setupProject(projectPath, filePaths)
     })
 
-    it("finds API test for API implementation", () =>
+    it('finds API test for API implementation', () =>
       waitsForPromise(() =>
         Matchmaker.for('app/api/git_commits.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -277,7 +277,7 @@ describe("finding the complementary path for a file", () => {
       )
     )
 
-    it("finds API implementation for API test", () =>
+    it('finds API implementation for API test', () =>
       waitsForPromise(() =>
         Matchmaker.for('test/integration/api/git_commits_test.rb').complementaryPath().then(complementaryPath =>
           expect(complementaryPath)
@@ -287,15 +287,15 @@ describe("finding the complementary path for a file", () => {
     )
   })
 
-  describe("when no complementary path exists", () => {
+  describe('when no complementary path exists', () => {
     beforeEach(() => {
       let filePaths = [
-        'lib/main.coffee',
+        'lib/main.coffee'
       ]
       setupProject(projectPath, filePaths)
     })
 
-    it("resolves to null", () =>
+    it('resolves to null', () =>
       waitsForPromise(() =>
         Matchmaker.for('lib/main.coffee').complementaryPath().then(complementaryPath =>
           expect(complementaryPath).toBeNull()


### PR DESCRIPTION
Configure linter for [JavaScript Standard Style](https://standardjs.com) to foster consistency with the [Atom style guide](https://github.com/atom/atom/blob/acdf3b20bd94d58cca74e167108278266b2e3670/CONTRIBUTING.md#javascript-styleguide).

### TODO

- [x] Set up [JavaScript Standard Style](https://standardjs.com) linter
- [x] Resolve existing linter violations
